### PR TITLE
Add broader regression and validation tests

### DIFF
--- a/califorcia/frequency_summation.py
+++ b/califorcia/frequency_summation.py
@@ -34,7 +34,7 @@ def psd_sum(T, L, func, epsrel, order=None):
     return 0.5*k*T*res
 
 
-def msd_sum(T, L, func, epsrel, nmax=None):
+def msd_sum(T, L, func, epsrel, order=None):
     """Computes the PSD sum for the finite frequency/wavenumber contributions
 
     Parameters
@@ -58,8 +58,10 @@ def msd_sum(T, L, func, epsrel, nmax=None):
     K_matsubara = 2 * np.pi * k * T / (hbar * c)
     res = np.zeros(2)
     n = 1
-    if nmax == None:
+    if order == None:
         nmax = np.inf
+    else:
+        nmax = order
 
     while (n <= nmax):
         term = func(K_matsubara * n)

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,81 @@
+import pytest
+from numpy.testing import assert_allclose
+
+from califorcia.compute import system
+from califorcia.materials import ethanol, gold, gold_plasma, teflon, vacuum
+
+
+class LorentzDielectric:
+    def __init__(self):
+        self.materialclass = "dielectric"
+
+    def epsilon(self, xi):
+        return 1.0 + 1.5e30 / (1.0e30 + xi**2)
+
+
+class PlasmaMetal:
+    def __init__(self, wp):
+        self.materialclass = "plasma"
+        self.wp = wp
+
+    def epsilon(self, xi):
+        return 1.0 + self.wp**2 / xi**2
+
+
+def test_psd_and_msd_agree_for_dielectric_system():
+    s = system(300.0, 200e-9, teflon, teflon, vacuum)
+    pressure_psd = s.pressure(fs="psd", epsrel=1e-7)
+    pressure_msd = s.pressure(fs="msd", epsrel=1e-7, N=200)
+    assert_allclose(pressure_psd, pressure_msd, rtol=1e-5)
+
+
+def test_psd_and_msd_agree_for_metallic_system():
+    s = system(300.0, 1e-6, gold, gold, vacuum)
+    energy_psd = s.energy(fs="psd", epsrel=1e-7)
+    energy_msd = s.energy(fs="msd", epsrel=1e-7, N=250)
+    assert_allclose(energy_psd, energy_msd, rtol=1e-5)
+
+
+def test_swapping_left_and_right_planes_keeps_pressure_invariant():
+    left = system(300.0, 120e-9, gold, teflon, ethanol)
+    right = system(300.0, 120e-9, teflon, gold, ethanol)
+    assert_allclose(left.pressure(), right.pressure(), rtol=1e-12)
+
+
+def test_zero_thickness_coating_reduces_to_bare_halfspace():
+    coated = system(300.0, 1e-6, [teflon, gold], gold, vacuum, deltaL=[0.0])
+    bare = system(300.0, 1e-6, gold, gold, vacuum)
+    assert_allclose(coated.pressure(), bare.pressure(), rtol=1e-10)
+
+
+def test_identical_coating_and_substrate_match_uncoated_case():
+    coated = system(300.0, 1e-6, [gold, gold], gold, vacuum, deltaL=[50e-9])
+    bare = system(300.0, 1e-6, gold, gold, vacuum)
+    assert_allclose(coated.energy(), bare.energy(), rtol=1e-10)
+
+
+def test_left_and_right_coating_are_symmetric():
+    left = system(300.0, 1e-6, [teflon, gold], gold, vacuum, deltaL=[50e-9])
+    right = system(300.0, 1e-6, gold, [teflon, gold], vacuum, deltaR=[50e-9])
+    assert_allclose(left.pressuregradient(), right.pressuregradient(), rtol=1e-10)
+
+
+def test_pressure_matches_finite_difference_of_energy():
+    d = 500e-9
+    step = 1e-9
+    s = system(300.0, d, gold, gold, vacuum)
+    s_plus = system(300.0, d + step, gold, gold, vacuum)
+    s_minus = system(300.0, d - step, gold, gold, vacuum)
+    finite_difference = -(s_plus.energy() - s_minus.energy()) / (2 * step)
+    assert_allclose(s.pressure(), finite_difference, rtol=5e-4)
+
+
+def test_custom_dielectric_material_can_be_used_in_system():
+    s = system(300.0, 100e-9, gold, LorentzDielectric(), ethanol)
+    assert pytest.approx(0.22099374769016233, rel=1e-12) == s.pressure()
+
+
+def test_custom_plasma_material_matches_builtin_gold_plasma():
+    s_builtin = system(300.0, 1e-6, gold_plasma, gold_plasma, vacuum)
+    s_custom = system(300.0, 1e-6, PlasmaMetal(gold_plasma.wp), PlasmaMetal(gold_plasma.wp), vacuum)
+    assert_allclose(s_custom.pressure(), s_builtin.pressure(), rtol=1e-12)

--- a/tests/test_plane.py
+++ b/tests/test_plane.py
@@ -1,0 +1,38 @@
+from math import sqrt
+
+from numpy.testing import assert_allclose
+
+from califorcia.plane import def_fresnel_coefficients, def_reflection_coeff, kappa
+from califorcia.materials import gold_drude, gold_plasma, pec, teflon, vacuum
+
+
+def test_kappa_zero_frequency_depends_on_materialclass():
+    kval = 2.0
+    assert_allclose(kappa(teflon, 0.0, kval), kval)
+    assert_allclose(kappa(gold_drude, 0.0, kval), kval)
+    assert_allclose(kappa(gold_plasma, 0.0, kval), sqrt((gold_plasma.wp / 299792458.0) ** 2 + kval**2))
+
+
+def test_fresnel_coefficients_for_pec_are_exact():
+    fresnel = def_fresnel_coefficients(vacuum, pec)
+    assert fresnel(0.0, 1.0) == (1.0, -1.0)
+    assert fresnel(1.0, 1.0) == (1.0, -1.0)
+
+
+def test_dielectric_dielectric_zero_frequency_te_mode_vanishes():
+    fresnel = def_fresnel_coefficients(vacuum, teflon)
+    r_tm, r_te = fresnel(0.0, 1.0)
+    assert_allclose(r_te, 0.0, atol=0.0)
+    assert r_tm > 0.0
+
+
+def test_zero_thickness_multilayer_reflection_reduces_to_single_interface():
+    multilayer = def_reflection_coeff(vacuum, [teflon, gold_drude], [0.0])
+    single = def_reflection_coeff(vacuum, [gold_drude], [])
+    assert_allclose(multilayer(1.2, 0.7), single(1.2, 0.7), rtol=1e-12)
+
+
+def test_identical_material_layers_reduce_to_same_reflection():
+    multilayer = def_reflection_coeff(vacuum, [gold_drude, gold_drude, gold_drude, gold_drude], [5e-9, 7e-9, 9e-9])
+    single = def_reflection_coeff(vacuum, [gold_drude], [])
+    assert_allclose(multilayer(1.2, 0.7), single(1.2, 0.7), rtol=1e-12)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -30,11 +30,15 @@ def test_zero_frequency():
     s = system(1/k, d, pec, pec, vacuum)
     # analytical result from: Bordag et al., Advances in the Casimir effect (Oxford University press, 2009), Eq. (14.5)
     assert_allclose(s.calculate('energy', ht_limit=True), -zeta3/8/pi/d**2)
+    assert_allclose(s.calculate('pressure', ht_limit=True), -zeta3/4/pi/d**3)
+    assert_allclose(s.calculate('pressuregradient', ht_limit=True), 3*zeta3/4/pi/d**4)
 
     d = 100.e-9
     s = system(1 / k, d, gold, gold, vacuum)
     # analytical result from: Bordag et al., Advances in the Casimir effect (Oxford University press, 2009), Eq. (14.7)
     assert_allclose(s.calculate('energy', ht_limit=True), -zeta3 / 16 / pi / d ** 2)
+    assert_allclose(s.calculate('pressure', ht_limit=True), -zeta3 / 8 / pi / d ** 3)
+    assert_allclose(s.calculate('pressuregradient', ht_limit=True), 3 * zeta3 / 8 / pi / d ** 4)
 
 if __name__ == '__main__':
     test_pec()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,26 @@
+import pytest
+
+from califorcia.compute import system
+from califorcia.materials import gold, vacuum
+
+
+def test_left_coating_length_mismatch_raises_value_error():
+    with pytest.raises(ValueError, match="len\\(matL\\)=len\\(deltaL\\)\\+1"):
+        system(300.0, 1e-6, [gold, gold], gold, vacuum, deltaL=[])
+
+
+def test_right_coating_length_mismatch_raises_value_error():
+    with pytest.raises(ValueError, match="len\\(matR\\)=len\\(deltaR\\)\\+1"):
+        system(300.0, 1e-6, gold, [gold, gold], vacuum, deltaR=[])
+
+
+def test_invalid_observable_raises_value_error():
+    s = system(300.0, 1e-6, gold, gold, vacuum)
+    with pytest.raises(ValueError, match="Supported values for 'observable'"):
+        s.calculate("force")
+
+
+def test_invalid_frequency_summation_method_raises_value_error():
+    s = system(300.0, 1e-6, gold, gold, vacuum)
+    with pytest.raises(ValueError, match="Supported values for fs"):
+        s.calculate("energy", fs="invalid")


### PR DESCRIPTION
## Summary

Adds broader test coverage for the Lifshitz implementation.

## Included

- extends exact-limit regression tests for `energy`, `pressure`, and `pressuregradient`
- adds `psd` vs `msd` consistency checks
- adds symmetry and coating-consistency tests
- adds custom material tests
- adds validation/error-path tests
- fixes the `msd` summation helper to accept the same `order`/`N` flow used by `system.calculate(...)`

## Notes

These tests are intended to cover:
- exact analytical limits where available
- physical consistency relations
- multilayer ordering/reduction behavior
- API validation behavior
