### PR TITLE
Fix custom dielectric regression test

### DIFF
--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -10,7 +10,9 @@ class LorentzDielectric:
         self.materialclass = "dielectric"
 
     def epsilon(self, xi):
-        return 1.0 + 1.5e30 / (1.0e30 + xi**2)
+        wj = 1.911e15
+        cj = 1.282
+        return 1.0 + cj * wj**2 / (wj**2 + xi**2)
 
 
 class PlasmaMetal:


### PR DESCRIPTION
## Summary

Fixes the custom dielectric regression test so it matches the documented Example 2 material model.

## Changes

- updates the `LorentzDielectric` test helper to use
  - `wj = 1.911e15`
  - `cj = 1.282`
  - `epsilon(xi) = 1 + cj * wj**2 / (wj**2 + xi**2)`

## Verification

Ran:

```powershell
& python -m pytest tests
