### PR TITLE
Set up GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+          python -m pip install -e .
+
+      - name: Run tests
+        run: python -m pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 califorcia.egg-info/
 env/
+.conda-test/
 build/
 dist/
+.pytest_cache/
+pytest-cache-files-*/
 
 misc/
 research/

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ pytest
 
 Current regression tests are in [`tests/test_results.py`](tests/test_results.py).
 
+GitHub Actions continuous integration is configured in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and runs the test suite automatically on pushes to `master` and on pull requests.
+
 ## Citation And Scientific Use
 
 If you use this package in research, it is a good idea to cite:

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,20 @@ They verify:
 - the perfect-conductor zero-temperature limit against Casimir's exact result
 - zero-frequency high-temperature limits for selected systems
 
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow at [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+
+It currently:
+
+- runs on pushes to `master`
+- runs on pull requests
+- tests against Python `3.11` and `3.12`
+- installs the package and test dependencies
+- runs `python -m pytest tests`
+
+This is a good first CI setup because it checks the most important question on every change: does the package still install and do the tests still pass?
+
 ## Source Layout
 
 - [`califorcia/compute.py`](../califorcia/compute.py): main `system` class and observable dispatch

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -10,7 +10,9 @@ class LorentzDielectric:
         self.materialclass = "dielectric"
 
     def epsilon(self, xi):
-        return 1.0 + 1.5e30 / (1.0e30 + xi**2)
+        wj = 1.911e15
+        cj = 1.282
+        return 1.0 + cj * wj**2 / (wj**2 + xi**2)
 
 
 class PlasmaMetal:


### PR DESCRIPTION
## Summary

Sets up a first GitHub Actions continuous integration workflow for the project.

## Changes

- adds a GitHub Actions workflow at `.github/workflows/ci.yml`
- runs the test suite automatically on pushes to `master` and on pull requests
- tests the package on Python `3.11` and `3.12`
- installs dependencies and runs `python -m pytest tests`
- updates `.gitignore` for local test and environment artifacts
- adds short CI notes to the README and development docs
- fixes the custom dielectric regression test so the documented example and test input match

## Why

This gives the project a basic automated check that verifies whether the package still installs and whether the test suite still passes after each change.

## Verification

Locally verified with:

```powershell
& python -m pytest tests
