### PR TITLE
Validate solver inputs up front

### DIFF
--- a/califorcia/compute.py
+++ b/califorcia/compute.py
@@ -7,6 +7,9 @@ from scipy.constants import pi, c, hbar
 from scipy.integrate import quad
 from math import inf
 
+SUPPORTED_MATERIALCLASSES = {"dielectric", "drude", "plasma", "pec"}
+MAX_MATERIALS_PER_SIDE = 4
+
 class system:
     '''Class that defines the system of two parallel plates.
     '''
@@ -42,11 +45,47 @@ class system:
             self.matR = matR
         self.deltaR = deltaR
         self.matm = matm
+        self._validate_inputs()
+
+    def _validate_material(self, material, location):
+        if not hasattr(material, "materialclass"):
+            raise ValueError(f"Material '{location}' must define 'materialclass'.")
+
+        materialclass = material.materialclass
+        if materialclass not in SUPPORTED_MATERIALCLASSES:
+            raise ValueError(
+                f"Unsupported materialclass '{materialclass}' for material '{location}'. "
+                f"Supported values are {sorted(SUPPORTED_MATERIALCLASSES)}."
+            )
+
+        if not hasattr(material, "epsilon"):
+            raise ValueError(f"Material '{location}' must define 'epsilon(xi)'.")
+
+        if materialclass == "plasma" and not hasattr(material, "wp"):
+            raise ValueError(f"Material '{location}' with materialclass 'plasma' must define 'wp'.")
+
+    def _validate_inputs(self):
+        if self.d <= 0.0:
+            raise ValueError("The plate separation d must be positive.")
 
         if not len(self.matL) == len(self.deltaL) + 1:
             raise ValueError("A thickness needs to be assigned to each coating layer on plate L, i.e. len(matL)=len(deltaL)+1 must hold.")
         if not len(self.matR) == len(self.deltaR) + 1:
             raise ValueError("A thickness needs to be assigned to each coating layer on plate R, i.e. len(matR)=len(deltaR)+1 must hold.")
+        if len(self.matL) > MAX_MATERIALS_PER_SIDE:
+            raise ValueError(f"At most {MAX_MATERIALS_PER_SIDE} materials are supported on plate L.")
+        if len(self.matR) > MAX_MATERIALS_PER_SIDE:
+            raise ValueError(f"At most {MAX_MATERIALS_PER_SIDE} materials are supported on plate R.")
+        if any(thickness < 0.0 for thickness in self.deltaL):
+            raise ValueError("Coating thicknesses on plate L must be non-negative.")
+        if any(thickness < 0.0 for thickness in self.deltaR):
+            raise ValueError("Coating thicknesses on plate R must be non-negative.")
+
+        self._validate_material(self.matm, "matm")
+        for idx, material in enumerate(self.matL):
+            self._validate_material(material, f"matL[{idx}]")
+        for idx, material in enumerate(self.matR):
+            self._validate_material(material, f"matR[{idx}]")
 
     def frequency_function(self, observable):
         '''

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -24,3 +24,49 @@ def test_invalid_frequency_summation_method_raises_value_error():
     s = system(300.0, 1e-6, gold, gold, vacuum)
     with pytest.raises(ValueError, match="Supported values for fs"):
         s.calculate("energy", fs="invalid")
+
+
+def test_non_positive_separation_raises_value_error():
+    with pytest.raises(ValueError, match="must be positive"):
+        system(300.0, 0.0, gold, gold, vacuum)
+
+
+def test_negative_left_coating_thickness_raises_value_error():
+    with pytest.raises(ValueError, match="plate L must be non-negative"):
+        system(300.0, 1e-6, [gold, gold], gold, vacuum, deltaL=[-1e-9])
+
+
+def test_negative_right_coating_thickness_raises_value_error():
+    with pytest.raises(ValueError, match="plate R must be non-negative"):
+        system(300.0, 1e-6, gold, [gold, gold], vacuum, deltaR=[-1e-9])
+
+
+def test_more_than_four_materials_on_left_plate_raises_value_error():
+    with pytest.raises(ValueError, match="At most 4 materials"):
+        system(300.0, 1e-6, [gold, gold, gold, gold, gold], gold, vacuum, deltaL=[1e-9, 1e-9, 1e-9, 1e-9])
+
+
+class UnsupportedMaterial:
+    materialclass = "mystery"
+
+    @staticmethod
+    def epsilon(xi):
+        return 1.0
+
+
+class PlasmaMaterialWithoutWp:
+    materialclass = "plasma"
+
+    @staticmethod
+    def epsilon(xi):
+        return 2.0
+
+
+def test_unsupported_materialclass_raises_value_error():
+    with pytest.raises(ValueError, match="Unsupported materialclass"):
+        system(300.0, 1e-6, UnsupportedMaterial(), gold, vacuum)
+
+
+def test_plasma_material_without_wp_raises_value_error():
+    with pytest.raises(ValueError, match="must define 'wp'"):
+        system(300.0, 1e-6, PlasmaMaterialWithoutWp(), gold, vacuum)


### PR DESCRIPTION
## Summary

Adds upfront validation for system inputs so invalid configurations fail early with clearer error messages.

## Changes

- validates that the plate separation `d` is positive
- validates that no more than 4 materials are provided on either side
- validates that coating thicknesses are non-negative
- validates that each material defines a supported `materialclass`
- validates that each material defines `epsilon(xi)`
- validates that plasma materials define `wp`

## Tests

Adds validation coverage for:

- non-positive separation
- negative left/right coating thickness
- too many materials on one side
- unsupported `materialclass`
- plasma material without `wp`

## Why

Previously, some invalid inputs would only fail later in the calculation, often with less clear runtime errors. This change makes the API stricter and easier to use by catching these issues at construction time.

## Verification

Locally verified with:

```bash
python -m pytest tests
