### PR TITLE
Reduce repeated work in interaction kernels

### DIFF
--- a/califorcia/interaction.py
+++ b/califorcia/interaction.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import quad
+from scipy.integrate import quad_vec
 from math import sqrt, exp, inf, log1p, pi
 from scipy.constants import c
 
@@ -32,6 +32,12 @@ def k_integrand_energy(k, k0, d, epsm, rL, rR):
     res_TM = k / 2 / pi * log1p(- rTM_L * rTM_R * exp(-2 * kappa * d))
     return res_TE, res_TM
 
+def _integrate_k0_contribution(integrand, k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
+    epsm = epsm_func(k0 * c)
+    f = lambda t: np.array(integrand(t / d, k0, d, epsm, rL, rR)) / d
+    return quad_vec(f, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
+
+
 def k0_func_energy(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
     """
     Casimir free energy contribution at a given wave number k0.
@@ -52,11 +58,7 @@ def k0_func_energy(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
     numpy array of two floats
         result for TE and TM polarization
     """
-    f_TE = lambda t: k_integrand_energy(t/d, k0, d, epsm_func(k0 * c), rL, rR)[0]/d
-    res_TE = quad(f_TE, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    f_TM = lambda t: k_integrand_energy(t/d, k0, d, epsm_func(k0 * c), rL, rR)[1]/d
-    res_TM = quad(f_TM, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    return np.array([res_TE, res_TM])
+    return _integrate_k0_contribution(k_integrand_energy, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)
 
 def k_integrand_pressure(k, k0, d, epsm, rL, rR):
     """
@@ -107,11 +109,7 @@ def k0_func_pressure(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
     numpy array of two floats
         result for TE and TM polarization
     """
-    f_TE = lambda t: k_integrand_pressure(t / d, k0, d, epsm_func(k0 * c), rL, rR)[0] / d
-    res_TE = quad(f_TE, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    f_TM = lambda t: k_integrand_pressure(t / d, k0, d, epsm_func(k0 * c), rL, rR)[1] / d
-    res_TM = quad(f_TM, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    return np.array([res_TE, res_TM])
+    return _integrate_k0_contribution(k_integrand_pressure, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)
 
 def k_integrand_pressuregradient(k, k0, d, epsm, rL, rR):
     """
@@ -161,8 +159,4 @@ def k0_func_pressuregradient(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0)
     numpy array of two floats
         result for TE and TM polarization
     """
-    f_TE = lambda t: k_integrand_pressuregradient(t / d, k0, d, epsm_func(k0 * c), rL, rR)[0] / d
-    res_TE = quad(f_TE, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    f_TM = lambda t: k_integrand_pressuregradient(t / d, k0, d, epsm_func(k0 * c), rL, rR)[1] / d
-    res_TM = quad(f_TM, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-    return np.array([res_TE, res_TM])
+    return _integrate_k0_contribution(k_integrand_pressuregradient, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)


### PR DESCRIPTION
## Summary

Reduces repeated work inside the interaction kernels by sharing the per-frequency setup and integrating the TE and TM contributions together.

## Changes

- adds a shared `_integrate_k0_contribution(...)` helper in `califorcia/interaction.py`
- computes `epsm = epsm_func(k0 * c)` once per `k0` instead of recomputing it multiple times
- replaces separate TE and TM scalar quadratures with a single vector-valued `quad_vec(...)` integration
- preserves the existing public API and keeps the already-merged `epsrel` / `epsabs` tolerance controls

## Why

Previously, each observable-specific kernel recomputed the medium response multiple times for the same `k0`, and TE and TM were integrated in separate passes. This introduced avoidable repeated work in the hottest numerical path.

With this change, the per-frequency setup is shared and both polarization channels are integrated together, making the implementation shorter and more efficient while preserving behavior.

## Verification

Locally verified with:

```bash
python -m pytest tests
