### PR TITLE
Cover remaining test ideas

### DIFF
--- a/califorcia/plane.py
+++ b/califorcia/plane.py
@@ -90,6 +90,8 @@ def def_fresnel_coefficients(mat1, mat2):
     """
     def fresnel_coefficients(k0, k):
         rTM, rTE = 0., 0.
+        if mat1.materialclass == "pec":
+            return -1., 1.
         if mat2.materialclass == "pec":
             return 1., -1.
         if k0 == 0.:

--- a/tests/ideas.txt
+++ b/tests/ideas.txt
@@ -1,5 +1,0 @@
-* implement PEC as material and check that we obtain Casimir's result correctly
-* check that energy, force, and forcegradient are actually derivatives of each other
-* implement high-temperature limit and check against analytical results
-* check what happens if we coat with vacuum, does that just effectively change the separation?
-* test reflection coefficients: pec on top will ignore everything under, thinner coating means reflection coefficient is smaller, etc.

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -85,6 +85,23 @@ def test_pressure_matches_finite_difference_of_energy():
     assert_allclose(s.pressure(), finite_difference, rtol=5e-4)
 
 
+def test_pressuregradient_matches_finite_difference_of_pressure():
+    d = 500e-9
+    step = 1e-9
+    s = system(300.0, d, gold, gold, vacuum)
+    s_plus = system(300.0, d + step, gold, gold, vacuum)
+    s_minus = system(300.0, d - step, gold, gold, vacuum)
+    finite_difference = (s_plus.pressure() - s_minus.pressure()) / (2 * step)
+    assert_allclose(s.pressuregradient(), finite_difference, rtol=5e-4)
+
+
+def test_vacuum_coating_in_vacuum_shifts_effective_separation():
+    coating_thickness = 50e-9
+    coated = system(300.0, 1e-6, [vacuum, gold], gold, vacuum, deltaL=[coating_thickness])
+    shifted = system(300.0, 1e-6 + coating_thickness, gold, gold, vacuum)
+    assert_allclose(coated.pressure(), shifted.pressure(), rtol=1e-7)
+
+
 def test_custom_dielectric_material_can_be_used_in_system():
     s = system(300.0, 100e-9, gold, LorentzDielectric(), ethanol)
     assert pytest.approx(0.22099374769016233, rel=1e-12) == s.pressure()

--- a/tests/test_plane.py
+++ b/tests/test_plane.py
@@ -46,3 +46,9 @@ def test_many_identical_material_layers_reduce_to_same_reflection():
     )
     single = def_reflection_coeff(vacuum, [gold_drude], [])
     assert_allclose(multilayer(1.2, 0.7), single(1.2, 0.7), rtol=1e-12)
+
+
+def test_pec_top_layer_ignores_underlying_stack():
+    coated = def_reflection_coeff(vacuum, [pec, gold_drude, teflon, gold_drude], [5e-9, 7e-9, 9e-9])
+    bare = def_reflection_coeff(vacuum, [pec], [])
+    assert_allclose(coated(1.2, 0.7), bare(1.2, 0.7), rtol=1e-12)


### PR DESCRIPTION
## Summary

Covers the remaining testing ideas from `tests/ideas.txt` and removes the ideas file now that those cases are encoded as actual tests.

## Changes

- adds a finite-difference test that checks `pressuregradient` as the derivative of `pressure`
- adds a vacuum-coating test that checks a vacuum layer in vacuum behaves like an effective shift in separation
- adds a reflection-coefficient test showing that a PEC top layer screens the underlying stack
- fixes the reflection-coefficient logic so PEC works cleanly when it appears as the incident-side material inside the recursive multilayer construction
- removes `tests/ideas.txt`

## Why

These ideas were already identified as useful coverage targets, but they were still only listed in a note file rather than enforced by the test suite.

This PR turns those ideas into executable regression tests and closes one small PEC edge case uncovered by the new reflection test.

## Verification

Locally verified with:

```bash
python -m pytest tests
