### PR TITLE
Split zero and finite frequency Fresnel paths

### DIFF
--- a/califorcia/_optional_numba.py
+++ b/califorcia/_optional_numba.py
@@ -1,0 +1,17 @@
+try:
+    from numba import njit as _njit
+except ImportError:
+    _njit = None
+
+
+def optional_njit(*args, **kwargs):
+    if _njit is None:
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+    return _njit(*args, **kwargs)

--- a/califorcia/compute.py
+++ b/califorcia/compute.py
@@ -110,7 +110,19 @@ class system:
         rR = def_reflection_coeff(self.matm, self.matR, self.deltaR)
 
         # define frequency (wave vector) integrand/summand
-        return lambda k0: func(k0, self.d, self.matm.epsilon, rL, rR, epsrel=epsrel, epsabs=epsabs)
+        return lambda k0: func(
+            k0,
+            self.d,
+            self.matm,
+            self.matL,
+            self.deltaL,
+            self.matR,
+            self.deltaR,
+            rL,
+            rR,
+            epsrel=epsrel,
+            epsabs=epsabs,
+        )
 
     def calculate(self, observable, ht_limit=False, fs='psd', epsrel=1.e-8, epsabs=0.0, N=None):
         '''

--- a/califorcia/interaction.py
+++ b/califorcia/interaction.py
@@ -3,28 +3,11 @@ from scipy.integrate import quad_vec
 from math import sqrt, exp, inf, log1p, pi
 from scipy.constants import c
 
+from ._optional_numba import optional_njit
+from .plane import evaluate_eps_stack, reflection_coefficients_finite
+
+
 def k_integrand_energy(k, k0, d, epsm, rL, rR):
-    """
-    Integrand of the radial part of in-plane wave vector for the Casimir energy.
-
-    Parameters
-    ----------
-    k : float
-        in-plane wave vector
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm : float
-        dielectric function of the medium evaluated at the vacuum wave number
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
-
-    Returns
-    -------
-    (float, float)
-        result for TE and TM polarization
-    """
     kappa = sqrt(epsm * k0 ** 2 + k ** 2)
     rTM_L, rTE_L = rL(k0, k)
     rTM_R, rTE_R = rR(k0, k)
@@ -32,56 +15,8 @@ def k_integrand_energy(k, k0, d, epsm, rL, rR):
     res_TM = k / 2 / pi * log1p(- rTM_L * rTM_R * exp(-2 * kappa * d))
     return res_TE, res_TM
 
-def _integrate_k0_contribution(integrand, k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
-    epsm = epsm_func(k0 * c)
-    f = lambda t: np.array(integrand(t / d, k0, d, epsm, rL, rR)) / d
-    return quad_vec(f, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
-
-
-def k0_func_energy(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
-    """
-    Casimir free energy contribution at a given wave number k0.
-
-    Parameters
-    ----------
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm_func : function
-        dielectric function of the medium
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
-
-    Returns
-    -------
-    numpy array of two floats
-        result for TE and TM polarization
-    """
-    return _integrate_k0_contribution(k_integrand_energy, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)
 
 def k_integrand_pressure(k, k0, d, epsm, rL, rR):
-    """
-    Integrand of the radial part of in-plane wave vector for the Casimir pressure.
-
-    Parameters
-    ----------
-    k : float
-        in-plane wave vector
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm : float
-        dielectric function of the medium evaluated at the vacuum wave number
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
-
-    Returns
-    -------
-    (float, float)
-        result for TE and TM polarization
-    """
     kappa = sqrt(epsm * k0 ** 2 + k ** 2)
     rTM_L, rTE_L = rL(k0, k)
     rTM_R, rTE_R = rR(k0, k)
@@ -89,49 +24,8 @@ def k_integrand_pressure(k, k0, d, epsm, rL, rR):
     res_TM = -2 * k * kappa / 2 / pi * rTM_L * rTM_R * exp(-2 * kappa * d) / (1 - rTM_L * rTM_R * exp(-2 * kappa * d))
     return res_TE, res_TM
 
-def k0_func_pressure(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
-    """
-    Casimir pressure contribution at a given wave number k0.
-
-    Parameters
-    ----------
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm_func : function
-        dielectric function of the medium
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
-
-    Returns
-    -------
-    numpy array of two floats
-        result for TE and TM polarization
-    """
-    return _integrate_k0_contribution(k_integrand_pressure, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)
 
 def k_integrand_pressuregradient(k, k0, d, epsm, rL, rR):
-    """
-    Integrand of the radial part of in-plane wave vector for the Casimir pressure gradient.
-
-    Parameters
-    ----------
-    k : float
-        in-plane wave vector
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm : float
-        dielectric function of the medium evaluated at the vacuum wave number
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
-    Returns
-    -------
-    (float, float)
-        result for TE and TM polarization
-    """
     kappa = sqrt(epsm * k0 ** 2 + k ** 2)
     rTM_L, rTE_L = rL(k0, k)
     rTM_R, rTE_R = rR(k0, k)
@@ -139,24 +33,79 @@ def k_integrand_pressuregradient(k, k0, d, epsm, rL, rR):
     res_TM = 4 * k * kappa ** 2 / 2 / pi * rTM_L * rTM_R * exp(-2 * kappa * d) / (1 - rTM_L * rTM_R * exp(-2 * kappa * d))**2
     return res_TE, res_TM
 
-def k0_func_pressuregradient(k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
-    """
-    Casimir pressure gradient contribution at a given wave number k0.
 
-    Parameters
-    ----------
-    k0 : float
-        vacuum wave number
-    d : float
-        separation between the two plates
-    epsm_func : function
-        dielectric function of the medium
-    rL, rR : float
-        reflection coefficient of the left and right plate, respectively
+@optional_njit(cache=True)
+def _finite_energy_integrand(k, k0, d, epsm, eps_layers_L, thicknesses_L, eps_layers_R, thicknesses_R):
+    kappa = sqrt(epsm * k0**2 + k**2)
+    rTM_L, rTE_L = reflection_coefficients_finite(epsm, eps_layers_L, thicknesses_L, k0, k)
+    rTM_R, rTE_R = reflection_coefficients_finite(epsm, eps_layers_R, thicknesses_R, k0, k)
+    res_TE = k / 2 / pi * log1p(-rTE_L * rTE_R * exp(-2 * kappa * d))
+    res_TM = k / 2 / pi * log1p(-rTM_L * rTM_R * exp(-2 * kappa * d))
+    return res_TE, res_TM
 
-    Returns
-    -------
-    numpy array of two floats
-        result for TE and TM polarization
-    """
-    return _integrate_k0_contribution(k_integrand_pressuregradient, k0, d, epsm_func, rL, rR, epsrel=epsrel, epsabs=epsabs)
+
+@optional_njit(cache=True)
+def _finite_pressure_integrand(k, k0, d, epsm, eps_layers_L, thicknesses_L, eps_layers_R, thicknesses_R):
+    kappa = sqrt(epsm * k0**2 + k**2)
+    rTM_L, rTE_L = reflection_coefficients_finite(epsm, eps_layers_L, thicknesses_L, k0, k)
+    rTM_R, rTE_R = reflection_coefficients_finite(epsm, eps_layers_R, thicknesses_R, k0, k)
+    res_TE = -2 * k * kappa / 2 / pi * rTE_L * rTE_R * exp(-2 * kappa * d) / (1 - rTE_L * rTE_R * exp(-2 * kappa * d))
+    res_TM = -2 * k * kappa / 2 / pi * rTM_L * rTM_R * exp(-2 * kappa * d) / (1 - rTM_L * rTM_R * exp(-2 * kappa * d))
+    return res_TE, res_TM
+
+
+@optional_njit(cache=True)
+def _finite_pressuregradient_integrand(k, k0, d, epsm, eps_layers_L, thicknesses_L, eps_layers_R, thicknesses_R):
+    kappa = sqrt(epsm * k0**2 + k**2)
+    rTM_L, rTE_L = reflection_coefficients_finite(epsm, eps_layers_L, thicknesses_L, k0, k)
+    rTM_R, rTE_R = reflection_coefficients_finite(epsm, eps_layers_R, thicknesses_R, k0, k)
+    res_TE = 4 * k * kappa**2 / 2 / pi * rTE_L * rTE_R * exp(-2 * kappa * d) / (1 - rTE_L * rTE_R * exp(-2 * kappa * d))**2
+    res_TM = 4 * k * kappa**2 / 2 / pi * rTM_L * rTM_R * exp(-2 * kappa * d) / (1 - rTM_L * rTM_R * exp(-2 * kappa * d))**2
+    return res_TE, res_TM
+
+
+def _integrate_k0_contribution(integrand, k0, d, epsm_func, rL, rR, epsrel=1.e-8, epsabs=0.0):
+    epsm = epsm_func(k0 * c)
+    f = lambda t: np.array(integrand(t / d, k0, d, epsm, rL, rR)) / d
+    return quad_vec(f, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
+
+
+def _integrate_k0_contribution_finite(integrand, k0, d, medium, matL, deltaL, matR, deltaR, epsrel=1.e-8, epsabs=0.0):
+    xi = k0 * c
+    epsm = medium.epsilon(xi)
+    eps_layers_L = evaluate_eps_stack(matL, xi)
+    eps_layers_R = evaluate_eps_stack(matR, xi)
+    thicknesses_L = np.asarray(deltaL, dtype=np.float64)
+    thicknesses_R = np.asarray(deltaR, dtype=np.float64)
+    f = lambda t: np.array(integrand(t / d, k0, d, epsm, eps_layers_L, thicknesses_L, eps_layers_R, thicknesses_R)) / d
+    return quad_vec(f, 0, inf, epsrel=epsrel, epsabs=epsabs)[0]
+
+
+def _supports_compiled_finite_path(medium, matL, matR):
+    if medium.materialclass == "pec":
+        return False
+    return all(material.materialclass != "pec" for material in matL) and all(material.materialclass != "pec" for material in matR)
+
+
+def k0_func_energy(k0, d, medium, matL, deltaL, matR, deltaR, rL_zero, rR_zero, epsrel=1.e-8, epsabs=0.0):
+    if k0 == 0.0:
+        return _integrate_k0_contribution(k_integrand_energy, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    if not _supports_compiled_finite_path(medium, matL, matR):
+        return _integrate_k0_contribution(k_integrand_energy, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    return _integrate_k0_contribution_finite(_finite_energy_integrand, k0, d, medium, matL, deltaL, matR, deltaR, epsrel=epsrel, epsabs=epsabs)
+
+
+def k0_func_pressure(k0, d, medium, matL, deltaL, matR, deltaR, rL_zero, rR_zero, epsrel=1.e-8, epsabs=0.0):
+    if k0 == 0.0:
+        return _integrate_k0_contribution(k_integrand_pressure, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    if not _supports_compiled_finite_path(medium, matL, matR):
+        return _integrate_k0_contribution(k_integrand_pressure, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    return _integrate_k0_contribution_finite(_finite_pressure_integrand, k0, d, medium, matL, deltaL, matR, deltaR, epsrel=epsrel, epsabs=epsabs)
+
+
+def k0_func_pressuregradient(k0, d, medium, matL, deltaL, matR, deltaR, rL_zero, rR_zero, epsrel=1.e-8, epsabs=0.0):
+    if k0 == 0.0:
+        return _integrate_k0_contribution(k_integrand_pressuregradient, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    if not _supports_compiled_finite_path(medium, matL, matR):
+        return _integrate_k0_contribution(k_integrand_pressuregradient, k0, d, medium.epsilon, rL_zero, rR_zero, epsrel=epsrel, epsabs=epsabs)
+    return _integrate_k0_contribution_finite(_finite_pressuregradient_integrand, k0, d, medium, matL, deltaL, matR, deltaR, epsrel=epsrel, epsabs=epsabs)

--- a/califorcia/plane.py
+++ b/califorcia/plane.py
@@ -1,7 +1,12 @@
 from math import sqrt, exp
+
+import numpy as np
 from scipy.constants import c
 
+from ._optional_numba import optional_njit
 
+
+@optional_njit(cache=True)
 def _combine_reflection_coefficients(r_left, r_right, kappa_layer, thickness):
     phase = exp(-2 * kappa_layer * thickness)
     rTM_left, rTE_left = r_left
@@ -10,38 +15,125 @@ def _combine_reflection_coefficients(r_left, r_right, kappa_layer, thickness):
     rTE = (rTE_left + rTE_right * phase) / (1 + rTE_left * rTE_right * phase)
     return rTM, rTE
 
+
+@optional_njit(cache=True)
+def kappa_finite(eps, k0, k):
+    return sqrt(eps * k0**2 + k**2)
+
+
+def kappa_zero(mat, k):
+    if mat.materialclass == "dielectric":
+        return k
+    if mat.materialclass == "drude":
+        return k
+    if mat.materialclass == "plasma":
+        Kp = mat.wp / c
+        return sqrt(Kp**2 + k**2)
+    raise ValueError(f"Unsupported materialclass '{mat.materialclass}' in zero-frequency kappa.")
+
+
+def fresnel_coefficients_zero(mat1, mat2, k):
+    rTM, rTE = 0.0, 0.0
+    if mat1.materialclass == "pec":
+        return -1.0, 1.0
+    if mat2.materialclass == "pec":
+        return 1.0, -1.0
+    if mat1.materialclass == "dielectric":
+        if mat2.materialclass == "dielectric":
+            eps1 = mat1.epsilon(0.0)
+            eps2 = mat2.epsilon(0.0)
+            rTM = (eps2 - eps1) / (eps2 + eps1)
+            rTE = 0.0
+        elif mat2.materialclass == "drude":
+            rTM = 1.0
+            rTE = 0.0
+        elif mat2.materialclass == "plasma":
+            Kp = mat2.wp / c
+            rTM = 1.0
+            rTE = (k - sqrt(Kp**2 + k**2)) / (k + sqrt(Kp**2 + k**2))
+    elif mat1.materialclass == "drude":
+        if mat2.materialclass == "dielectric":
+            rTM = -1.0
+            rTE = 0.0
+        elif mat2.materialclass == "drude":
+            wp1 = mat1.wp
+            gamma1 = mat1.gamma
+            wp2 = mat2.wp
+            gamma2 = mat2.gamma
+            rTM = (gamma1 * wp2**2 - gamma2 * wp1**2) / (gamma1 * wp2**2 + gamma2 * wp1**2)
+            rTE = 0.0
+    elif mat1.materialclass == "plasma":
+        if mat2.materialclass == "dielectric":
+            Kp = mat1.wp / c
+            rTM = -1.0
+            rTE = -(k - sqrt(Kp**2 + k**2)) / (k + sqrt(Kp**2 + k**2))
+        elif mat2.materialclass == "plasma":
+            Kp1 = mat1.wp / c
+            Kp2 = mat2.wp / c
+            q1 = sqrt(Kp1**2 + k**2)
+            q2 = sqrt(Kp2**2 + k**2)
+            rTM = (Kp2**2 * q1 - Kp1**2 * q2) / (Kp2**2 * q1 + Kp1**2 * q2)
+            rTE = (q1 - q2) / (q1 + q2)
+    return rTM, rTE
+
+
+@optional_njit(cache=True)
+def fresnel_coefficients_finite(eps1, eps2, k0, k):
+    q1 = kappa_finite(eps1, k0, k)
+    q2 = kappa_finite(eps2, k0, k)
+    rTM = (eps2 * q1 - eps1 * q2) / (eps1 * q2 + eps2 * q1)
+    rTE = (q1 - q2) / (q2 + q1)
+    return rTM, rTE
+
+
+@optional_njit(cache=True)
+def reflection_coefficients_finite(eps_medium, eps_layers, thicknesses, k0, k):
+    nlayers = len(eps_layers)
+    if nlayers == 1:
+        return fresnel_coefficients_finite(eps_medium, eps_layers[0], k0, k)
+
+    effective_reflection = fresnel_coefficients_finite(eps_layers[nlayers - 2], eps_layers[nlayers - 1], k0, k)
+    for idx in range(nlayers - 3, -1, -1):
+        interface_reflection = fresnel_coefficients_finite(eps_layers[idx], eps_layers[idx + 1], k0, k)
+        effective_reflection = _combine_reflection_coefficients(
+            interface_reflection,
+            effective_reflection,
+            kappa_finite(eps_layers[idx + 1], k0, k),
+            thicknesses[idx + 1],
+        )
+
+    first_interface = fresnel_coefficients_finite(eps_medium, eps_layers[0], k0, k)
+    return _combine_reflection_coefficients(
+        first_interface,
+        effective_reflection,
+        kappa_finite(eps_layers[0], k0, k),
+        thicknesses[0],
+    )
+
+
+def evaluate_eps_stack(materials, xi):
+    return np.asarray([material.epsilon(xi) for material in materials], dtype=np.float64)
+
+
 def def_reflection_coeff(medium, materials, thicknesses):
     """
     Define reflection coefficients of the plane by specifying medium and materials of the plane and thickness of the
     coating layers.
-
-    Parameters
-    ----------
-    medium : object
-    materials : list of objects
-    thicknesses : list of floats
-
-    Returns
-    -------
-    function(float, float)->(float, float)
-        reflection coefficients taking vacuum wavenumber k0 and in-plane wave number k and returning the values of the
-        reflection coefficients for TM and TE polarization, respectively
-
     """
-    Nlayers = len(materials)
+    nlayers = len(materials)
     interface_coefficients = [def_fresnel_coefficients(medium, materials[0])]
     interface_coefficients.extend(
         def_fresnel_coefficients(materials[idx], materials[idx + 1])
-        for idx in range(Nlayers - 1)
+        for idx in range(nlayers - 1)
     )
 
-    if Nlayers == 1:
+    if nlayers == 1:
         return interface_coefficients[0]
 
     def reflection_coeff(k0, k):
         effective_reflection = interface_coefficients[-1](k0, k)
 
-        for idx in range(Nlayers - 2, 0, -1):
+        for idx in range(nlayers - 2, 0, -1):
             effective_reflection = _combine_reflection_coefficients(
                 interface_coefficients[idx](k0, k),
                 effective_reflection,
@@ -58,85 +150,25 @@ def def_reflection_coeff(medium, materials, thicknesses):
 
     return reflection_coeff
 
+
 def kappa(mat, k0, k):
-    if k0 == 0.:
-        if mat.materialclass == "dielectric":
-            return k
-        elif mat.materialclass == "drude":
-            return k
-        elif mat.materialclass == "plasma":
-            Kp = mat.wp/c
-            return sqrt(Kp**2 + k**2)
-    else: # k0 > 0
-        return sqrt(mat.epsilon(k0*c)*k0**2 + k**2)
+    if k0 == 0.0:
+        return kappa_zero(mat, k)
+    return kappa_finite(mat.epsilon(k0 * c), k0, k)
 
 
 def def_fresnel_coefficients(mat1, mat2):
     """
     Defines Fresnel reflection coefficients for a halfspace.
-
-    Parameters
-    ----------
-    mat1 : object
-        material representing the medium from which the planewave is incident
-    mat2 : object
-        material of the halfspace
-
-    Returns
-    -------
-    function(float, float)->(float, float)
-        reflection coefficients taking vacuum wavenumber k0 and in-plane wave number k and returning the values of the
-        reflection coefficients for TM and TE polarization, respectively
     """
-    def fresnel_coefficients(k0, k):
-        rTM, rTE = 0., 0.
-        if mat2.materialclass == "pec":
-            return 1., -1.
-        if k0 == 0.:
-            if mat1.materialclass == "dielectric":
-                if mat2.materialclass == "dielectric":
-                    eps1 = mat1.epsilon(0.)
-                    eps2 = mat2.epsilon(0.)
-                    rTM = (eps2 - eps1)/(eps2 + eps1)
-                    rTE = 0.
-                elif mat2.materialclass == "drude":
-                    rTM = 1.
-                    rTE = 0.
-                elif mat2.materialclass == "plasma":
-                    Kp = mat2.wp/c
-                    rTM = 1.
-                    rTE = (k - sqrt(Kp**2 + k**2))/(k + sqrt(Kp**2 + k**2))
-            elif mat1.materialclass == "drude":
-                if mat2.materialclass == "dielectric":
-                    rTM = -1.
-                    rTE = 0.
-                elif mat2.materialclass == "drude":
-                    wp1 = mat1.wp
-                    gamma1 = mat1.gamma
-                    wp2 = mat2.wp
-                    gamma2 = mat2.gamma
-                    rTM = (gamma1*wp2**2 - gamma2*wp1**2)/(gamma1*wp2**2 + gamma2*wp1**2)
-                    rTE = 0.
-            elif mat1.materialclass == "plasma":
-                if mat2.materialclass == "dielectric":
-                    Kp = mat1.wp/c
-                    rTM = -1.
-                    rTE = -(k - sqrt(Kp**2 + k**2))/(k + sqrt(Kp**2 + k**2))
-                elif mat2.materialclass == "plasma":
-                    Kp1 = mat1.wp/c
-                    Kp2 = mat2.wp/c
-                    q1 = sqrt(Kp1**2 + k**2)
-                    q2 = sqrt(Kp2**2 + k**2)
-                    rTM = (Kp2**2*q1 - Kp1**2*q2)/(Kp2**2*q1 + Kp1**2*q2)
-                    rTE = (q1 - q2)/(q1 + q2)
-            
-        else: # k0 > 0
-            eps1 = mat1.epsilon(k0*c)
-            eps2 = mat2.epsilon(k0*c)
-            q1 = sqrt(eps1*k0**2 + k**2)
-            q2 = sqrt(eps2*k0**2 + k**2)
-            rTM = (eps2*q1 - eps1*q2)/(eps1*q2 + eps2*q1)
-            rTE = (q1 - q2)/(q2 + q1)
 
-        return rTM, rTE
+    def fresnel_coefficients(k0, k):
+        if mat1.materialclass == "pec":
+            return -1.0, 1.0
+        if mat2.materialclass == "pec":
+            return 1.0, -1.0
+        if k0 == 0.0:
+            return fresnel_coefficients_zero(mat1, mat2, k)
+        return fresnel_coefficients_finite(mat1.epsilon(k0 * c), mat2.epsilon(k0 * c), k0, k)
+
     return fresnel_coefficients

--- a/tests/test_plane.py
+++ b/tests/test_plane.py
@@ -1,8 +1,16 @@
 from math import sqrt
 
+import numpy as np
 from numpy.testing import assert_allclose
 
-from califorcia.plane import def_fresnel_coefficients, def_reflection_coeff, kappa
+from califorcia.plane import (
+    def_fresnel_coefficients,
+    def_reflection_coeff,
+    evaluate_eps_stack,
+    fresnel_coefficients_finite,
+    kappa,
+    reflection_coefficients_finite,
+)
 from califorcia.materials import gold_drude, gold_plasma, pec, teflon, vacuum
 
 
@@ -46,3 +54,20 @@ def test_many_identical_material_layers_reduce_to_same_reflection():
     )
     single = def_reflection_coeff(vacuum, [gold_drude], [])
     assert_allclose(multilayer(1.2, 0.7), single(1.2, 0.7), rtol=1e-12)
+
+
+def test_finite_frequency_fresnel_helper_matches_public_interface():
+    k0 = 1.2
+    k = 0.7
+    public = def_fresnel_coefficients(vacuum, teflon)
+    helper = fresnel_coefficients_finite(vacuum.epsilon(k0 * 299792458.0), teflon.epsilon(k0 * 299792458.0), k0, k)
+    assert_allclose(public(k0, k), helper, rtol=1e-12)
+
+
+def test_finite_frequency_reflection_helper_matches_public_interface():
+    k0 = 1.2
+    k = 0.7
+    public = def_reflection_coeff(vacuum, [teflon, gold_drude, teflon], [5e-9, 7e-9])
+    eps_layers = evaluate_eps_stack([teflon, gold_drude, teflon], k0 * 299792458.0)
+    helper = reflection_coefficients_finite(vacuum.epsilon(k0 * 299792458.0), eps_layers, np.array([5e-9, 7e-9]), k0, k)
+    assert_allclose(public(k0, k), helper, rtol=1e-12)


### PR DESCRIPTION
## Summary

Splits the Fresnel and reflection-coefficient logic into separate zero-frequency and finite-frequency paths, and introduces a Numba-friendly finite-frequency numerical path for the inner `k`-integrand evaluation.

## Changes

### Fresnel / reflection split

- separates zero-frequency and finite-frequency Fresnel logic in `califorcia/plane.py`
- adds:
  - `fresnel_coefficients_zero(...)`
  - `fresnel_coefficients_finite(...)`
  - `kappa_finite(...)`
  - `reflection_coefficients_finite(...)`
  - `evaluate_eps_stack(...)`

### Optional compiled path

- adds `califorcia/_optional_numba.py`
- uses an optional `njit` wrapper so the numerical helpers remain valid Python even if `numba` is not installed
- keeps the public API unchanged

### Interaction path changes

- updates `califorcia/interaction.py` so:
  - the zero-frequency contribution still uses the general material-aware path
  - the finite-frequency contribution can use pre-evaluated permittivities and a purely numerical reflection/integrand path
- keeps a fallback to the generic path for finite-frequency PEC-containing systems

### Tests

- adds tests showing the new finite-frequency helper functions agree with the existing public Fresnel/reflection interface

## Why

The long-term goal is to make the hot finite-frequency `k`-integrand path friendlier to JIT compilation.

At finite frequency, the reflection problem can be expressed in terms of already-evaluated permittivities rather than Python material objects. This makes the inner numerical path much easier to compile while preserving the existing high-level API and leaving the more special zero-frequency logic separate.

This PR does not try to compile the whole solver. Instead, it introduces the structural split needed for a future compiled fast path.

## Notes

- `scipy.integrate` still drives the quadrature
- the main optimization target here is the cost of the integrand evaluation itself
- PEC-containing finite-frequency stacks still use the generic fallback path
- the implementation remains correct without `numba` installed

## Verification

Locally verified with:

```bash
python -m pytest tests
