### PR TITLE
Test recursive reflection against legacy formulas

### DIFF
--- a/tests/test_plane.py
+++ b/tests/test_plane.py
@@ -1,9 +1,95 @@
-from math import sqrt
+from math import sqrt, exp
 
 from numpy.testing import assert_allclose
 
 from califorcia.plane import def_fresnel_coefficients, def_reflection_coeff, kappa
 from califorcia.materials import gold_drude, gold_plasma, pec, teflon, vacuum
+
+
+def legacy_reflection_coeff(medium, materials, thicknesses):
+    nlayers = len(materials)
+
+    if nlayers == 1:
+        return def_fresnel_coefficients(medium, materials[0])
+
+    if nlayers == 2:
+        mat1 = materials[0]
+        mat2 = materials[1]
+        d1 = thicknesses[0]
+        fresnelm1 = def_fresnel_coefficients(medium, mat1)
+        fresnel12 = def_fresnel_coefficients(mat1, mat2)
+
+        def reflection_coeff(k0, k):
+            rTMm1, rTEm1 = fresnelm1(k0, k)
+            rTM12, rTE12 = fresnel12(k0, k)
+            kappa1 = kappa(mat1, k0, k)
+            rTM = (rTMm1 + rTM12 * exp(-2 * kappa1 * d1)) / (1 + rTMm1 * rTM12 * exp(-2 * kappa1 * d1))
+            rTE = (rTEm1 + rTE12 * exp(-2 * kappa1 * d1)) / (1 + rTEm1 * rTE12 * exp(-2 * kappa1 * d1))
+            return rTM, rTE
+
+        return reflection_coeff
+
+    if nlayers == 3:
+        mat1 = materials[0]
+        mat2 = materials[1]
+        mat3 = materials[2]
+        d1 = thicknesses[0]
+        d2 = thicknesses[1]
+        fresnelm1 = def_fresnel_coefficients(medium, mat1)
+        fresnel12 = def_fresnel_coefficients(mat1, mat2)
+        fresnel23 = def_fresnel_coefficients(mat2, mat3)
+
+        def reflection_coeff(k0, k):
+            rTMm1, rTEm1 = fresnelm1(k0, k)
+            rTM12, rTE12 = fresnel12(k0, k)
+            rTM23, rTE23 = fresnel23(k0, k)
+            kappa1 = kappa(mat1, k0, k)
+            kappa2 = kappa(mat2, k0, k)
+
+            rTM12_eff = (rTM12 + rTM23 * exp(-2 * kappa2 * d2)) / (1 + rTM12 * rTM23 * exp(-2 * kappa2 * d2))
+            rTE12_eff = (rTE12 + rTE23 * exp(-2 * kappa2 * d2)) / (1 + rTE12 * rTE23 * exp(-2 * kappa2 * d2))
+
+            rTM = (rTMm1 + rTM12_eff * exp(-2 * kappa1 * d1)) / (1 + rTMm1 * rTM12_eff * exp(-2 * kappa1 * d1))
+            rTE = (rTEm1 + rTE12_eff * exp(-2 * kappa1 * d1)) / (1 + rTEm1 * rTE12_eff * exp(-2 * kappa1 * d1))
+            return rTM, rTE
+
+        return reflection_coeff
+
+    if nlayers == 4:
+        mat1 = materials[0]
+        mat2 = materials[1]
+        mat3 = materials[2]
+        mat4 = materials[3]
+        d1 = thicknesses[0]
+        d2 = thicknesses[1]
+        d3 = thicknesses[2]
+        fresnelm1 = def_fresnel_coefficients(medium, mat1)
+        fresnel12 = def_fresnel_coefficients(mat1, mat2)
+        fresnel23 = def_fresnel_coefficients(mat2, mat3)
+        fresnel34 = def_fresnel_coefficients(mat3, mat4)
+
+        def reflection_coeff(k0, k):
+            rTMm1, rTEm1 = fresnelm1(k0, k)
+            rTM12, rTE12 = fresnel12(k0, k)
+            rTM23, rTE23 = fresnel23(k0, k)
+            rTM34, rTE34 = fresnel34(k0, k)
+            kappa1 = kappa(mat1, k0, k)
+            kappa2 = kappa(mat2, k0, k)
+            kappa3 = kappa(mat3, k0, k)
+
+            rTM23_eff = (rTM23 + rTM34 * exp(-2 * kappa3 * d3)) / (1 + rTM23 * rTM34 * exp(-2 * kappa3 * d3))
+            rTE23_eff = (rTE23 + rTE34 * exp(-2 * kappa3 * d3)) / (1 + rTE23 * rTE34 * exp(-2 * kappa3 * d3))
+
+            rTM12_eff = (rTM12 + rTM23_eff * exp(-2 * kappa2 * d2)) / (1 + rTM12 * rTM23_eff * exp(-2 * kappa2 * d2))
+            rTE12_eff = (rTE12 + rTE23_eff * exp(-2 * kappa2 * d2)) / (1 + rTE12 * rTE23_eff * exp(-2 * kappa2 * d2))
+
+            rTM = (rTMm1 + rTM12_eff * exp(-2 * kappa1 * d1)) / (1 + rTMm1 * rTM12_eff * exp(-2 * kappa1 * d1))
+            rTE = (rTEm1 + rTE12_eff * exp(-2 * kappa1 * d1)) / (1 + rTEm1 * rTE12_eff * exp(-2 * kappa1 * d1))
+            return rTM, rTE
+
+        return reflection_coeff
+
+    raise ValueError("legacy_reflection_coeff only supports up to 4 materials.")
 
 
 def test_kappa_zero_frequency_depends_on_materialclass():
@@ -52,3 +138,27 @@ def test_pec_top_layer_ignores_underlying_stack():
     coated = def_reflection_coeff(vacuum, [pec, gold_drude, teflon, gold_drude], [5e-9, 7e-9, 9e-9])
     bare = def_reflection_coeff(vacuum, [pec], [])
     assert_allclose(coated(1.2, 0.7), bare(1.2, 0.7), rtol=1e-12)
+
+
+def test_recursive_reflection_matches_legacy_formula_for_one_material():
+    recursive = def_reflection_coeff(vacuum, [teflon], [])
+    legacy = legacy_reflection_coeff(vacuum, [teflon], [])
+    assert_allclose(recursive(1.2, 0.7), legacy(1.2, 0.7), rtol=1e-12)
+
+
+def test_recursive_reflection_matches_legacy_formula_for_two_materials():
+    recursive = def_reflection_coeff(vacuum, [teflon, gold_drude], [5e-9])
+    legacy = legacy_reflection_coeff(vacuum, [teflon, gold_drude], [5e-9])
+    assert_allclose(recursive(1.2, 0.7), legacy(1.2, 0.7), rtol=1e-12)
+
+
+def test_recursive_reflection_matches_legacy_formula_for_three_materials():
+    recursive = def_reflection_coeff(vacuum, [teflon, gold_drude, teflon], [5e-9, 7e-9])
+    legacy = legacy_reflection_coeff(vacuum, [teflon, gold_drude, teflon], [5e-9, 7e-9])
+    assert_allclose(recursive(1.2, 0.7), legacy(1.2, 0.7), rtol=1e-12)
+
+
+def test_recursive_reflection_matches_legacy_formula_for_four_materials():
+    recursive = def_reflection_coeff(vacuum, [teflon, gold_drude, teflon, gold_drude], [5e-9, 7e-9, 9e-9])
+    legacy = legacy_reflection_coeff(vacuum, [teflon, gold_drude, teflon, gold_drude], [5e-9, 7e-9, 9e-9])
+    assert_allclose(recursive(1.2, 0.7), legacy(1.2, 0.7), rtol=1e-12)


### PR DESCRIPTION
## Summary

Adds regression tests that compare the current recursive multilayer reflection construction against the previous explicit 1-, 2-, 3-, and 4-material formulas.

## Changes

- adds a local `legacy_reflection_coeff(...)` helper in `tests/test_plane.py`
- adds direct comparison tests between:
  - the current recursive implementation
  - the previous explicit closed-form implementations
- covers the cases:
  - 1 material
  - 2 materials
  - 3 materials
  - 4 materials

## Why

The recursive multilayer implementation is intended to be algebraically equivalent to the earlier manually expanded formulas for small layer counts.

These tests lock in that equivalence and provide a direct regression guard for the reflection-coefficient logic.

## Verification

Locally verified with:

```bash
python -m pytest tests/test_plane.py
